### PR TITLE
Changing the script call so pytest can find all modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ python :
 install:
     - pip install -r docs/requirements.txt
 script:
-    - pytest
+    - cd tchelper && python -m pytest ../test/ -v

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -7,6 +7,21 @@ from unittest import mock
 import pytest
 
 
+def test_imports():
+    """
+    Test to see modules can be imported from the module being tested.
+
+    .. warning:: I am not sure if this is a vaild test. There must be a better way of doing this.
+    """
+
+    try:
+        from tchelper.config import configparser
+        from tchelper.config import os
+        #        from tchelper.config import os.path  # Doesn't want to work.
+    except ModuleNotFoundError as e:
+        pytest.fail(e, pytrace=True)
+
+
 @mock.patch('tchelper.config.os.path.isfile')
 @mock.patch('tchelper.config.os.access')
 @pytest.mark.parametrize('isfile, access, result', [(True, True, True),

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -1,0 +1,19 @@
+import pytest
+from tchelper.database import DB
+from tchelper.config import Config
+
+
+def test_imports():
+    """
+    Test to see modules can be imported from the module being tested.
+
+    .. warning:: I am not sure if this is a vaild test. There must be a better way of doing this.
+    """
+
+#     try:
+#         from tchelper.config import configparser
+#         from tchelper.config import os
+# #        from tchelper.config import os.path  # Doesn't want to work.
+#     except ModuleNotFoundError as e:
+#         pytest.fail(e, pytrace=True)
+    pass


### PR DESCRIPTION
PyTest was having a hard time finding my modules because it was being 
runed from outside of the working dir. Added `cd tchelper && python -m 
pytest ../test/ -v` to see if that would fix the issue.